### PR TITLE
Refactor GetOrg pipeline

### DIFF
--- a/PAFTOL_GetOrganelle/GetOrg_Pipeline.sh
+++ b/PAFTOL_GetOrganelle/GetOrg_Pipeline.sh
@@ -15,6 +15,27 @@
 ### 1.There is now only one sample list controlling which "pt" and "nr" runs are done - hope that's OK
 ### 2.The <paftol_export_file> is only used by GetOrg_prep.py - but leaving for now
 
+set -e
+
+if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+    echo "Usage: $0 <paftol_export> <DataSource> <fastqFilePath> <adapterFasta>"
+    echo
+    echo "Arguments:"
+    echo "  --skip-prep         Use flag to skip GetOrg_prep.py."
+    echo "  paftol_export:      PAFTOL export with the target samples (used by GetOrg_prep.py)."
+    echo "  DataSource:         PAFTOL, GAP, SRA... (used by GetOrg_prep.py)."
+    echo "  fastqFilePath:      Absolute path to the directory with symlinks to source files."
+    echo "  sampleList:         Use to override sample list files created by GetOrg_prep.py:"
+    echo "                          remaining_pt.txt and remaining_nr.txt."
+    echo "                      Use '' otherwise."
+    echo "                      Cols: idSequence,R1_fastq_file_name,R2_fastq_file_name with no headers."
+    echo "  adapterFasta:       (optional) Use to trim reads with Trimmomatic."
+    echo
+    echo "Used in GetOrg_prep.py:"
+    python GetOrg_prep.py --help
+    exit 0
+fi
+
 paftol_export=$1	# Paul B.: required by GetOrg_prep.py only
 DataSource=$2
 fastqFilePath=$3	# Paul B. added: replaces 'Data' folder in GetOrg_array.sh lines ~37 and ~42

--- a/PAFTOL_GetOrganelle/GetOrg_Pipeline.sh
+++ b/PAFTOL_GetOrganelle/GetOrg_Pipeline.sh
@@ -87,15 +87,44 @@ mkdir -p GetOrg; mkdir -p logs; mkdir -p fasta_pt; mkdir -p fasta_nr; mkdir -p A
 
 
 ## Launch remaining pt
-a=($(wc ../$sampleList)); Ns_pt=${a[0]}; echo $Ns_pt
-if (( $Ns_pt > 0 )); then
+#sampleList="remaining_pt.txt"
+#a=($(wc ../$sampleList)); Ns_pt=${a[0]}; echo $Ns_pt
+#if (( $Ns_pt > 0 )); then
 	### Paul B changed: sbatch --array=1-${Ns_pt}%$slurmThrottle ../GetOrg_array.sh remaining_pt.txt "pt"
-	sbatch --array=1-${Ns_pt}%$slurmThrottle ../GetOrg_array.sh ../${sampleList} "pt" $fastqFilePath $adapterFasta
-fi
+	#sbatch --array=1-${Ns_pt}%$slurmThrottle ../GetOrg_array.sh ../${sampleList} "pt" $fastqFilePath $adapterFasta
+#fi
 
 ## Launch remaining nr
-a=($(wc ../$sampleList)); Ns_nr=${a[0]}; echo $Ns_nr
-if (( $Ns_nr > 0 )); then
+#a=($(wc ../$sampleList)); Ns_nr=${a[0]}; echo $Ns_nr
+#if (( $Ns_nr > 0 )); then
 	### Paul B changed: sbatch --array=1-${Ns_nr}%$slurmThrottle ../GetOrg_array.sh remaining_nr.txt "nr"
-	sbatch --array=1-${Ns_nr}%$slurmThrottle ../GetOrg_array.sh ../${sampleList} "nr" $fastqFilePath $adapterFasta
+	#sbatch --array=1-${Ns_nr}%$slurmThrottle ../GetOrg_array.sh ../${sampleList} "nr" $fastqFilePath $adapterFasta
+#fi
+
+
+if [ ! -s "$sampleList" ]; then
+    echo "Using GetOrg_prep.py output (remaining_<pt/nr>.txt) as sample list."
+    use_prep_output=1
+    fastqFilePath="" # it is already in remaining_<pt/nr>.txt
+else
+    use_prep_output=0
 fi
+organelles=("pt" "nr")
+for org in "${organelles[@]}"; do
+    if [ "$use_prep_output" = 1 ]; then
+       sampleList="remaining_$org.txt" # assign the output from GetOrg_prep.py if not list given
+    fi
+
+    if [ ! -s "$sampleList" ]; then
+        echo "[ERROR] $sampleList missing or empty."
+        exit 1
+    fi
+
+    num_samples=$(wc -l < "$sampleList")
+    echo "$num_samples samples in $sampleList"
+
+    if (( num_samples > 0 )); then
+        sbatch --array=1-${num_samples}%${slurmThrottle:-1} \
+            ../GetOrg_array.sh "$sampleList" "$org" "$fastqFilePath" "$adapterFasta"
+    fi
+done

--- a/PAFTOL_GetOrganelle/GetOrg_Pipeline.sh
+++ b/PAFTOL_GetOrganelle/GetOrg_Pipeline.sh
@@ -21,7 +21,8 @@ fastqFilePath=$3	# Paul B. added: replaces 'Data' folder in GetOrg_array.sh line
 sampleList=$4		# Paul B. added: for manually creating list of samples to run and their fastq file names
 adapterFasta=$5		# Paul B. added: for adding the adaptor file, as required (might not be supplied)	
 rem_search="fasta" # log or fasta
-slurmThrottle=5
+slurmThrottle=2
+
 
 
 ## Make lists of remaining  samples that have no organelles recovered

--- a/PAFTOL_GetOrganelle/GetOrg_Pipeline.sh
+++ b/PAFTOL_GetOrganelle/GetOrg_Pipeline.sh
@@ -29,6 +29,18 @@ slurmThrottle=5
 # Paul B. removed: rm -f $DataSource/remaining_pt.txt
 # Paul B. removed: rm -f $DataSource/remaining_nr.txt;
 # Paul B. removed: python GetOrg_prep.py --db $paftol_export --DataSource $DataSource --rem_search $rem_search
+if [[ " $@ " =~ " --skip-prep " ]]; then
+    skip_prep=1
+else
+    skip_prep=0
+fi
+
+if (( skip_prep )); then
+    echo "[INFO] Skipping GetOrg_prep.py step."
+else
+    echo "[INFO] Running GetOrg_prep.py..."
+    python3 GetOrg_prep.py --db $paftol_export --DataSource $DataSource --src_path $fastqFilePath --rem_search $rem_search
+fi
 
 
 ## Go to dir and create working directories

--- a/PAFTOL_GetOrganelle/GetOrg_array.sh
+++ b/PAFTOL_GetOrganelle/GetOrg_array.sh
@@ -4,7 +4,7 @@
 #SBATCH --export=ALL
 #SBATCH --cpus-per-task=4
 #SBATCH --partition=long,himem	# Paul B. changed from all; NB - himem (gruffalo), hmem (KewHPC)
-#SBATCH --mem=80000
+#SBATCH --mem=32000
 #SBATCH --ntasks=1
 ncpu=4
 

--- a/PAFTOL_GetOrganelle/GetOrg_array.sh
+++ b/PAFTOL_GetOrganelle/GetOrg_array.sh
@@ -99,6 +99,7 @@ if [ -s "$fastqFilePath/$file_path_R2" ]; then
 	
 	if [ $org == pt ] 
 	then
+    echo "[INFO] Recovering plastomes..."
 		### Paul B. - added '--overwrite 'otherwise get organelle will not run if folder already exists
 		### Paul B. - replaced Data/ with $fastqFilePath in all 6 places below to make the file location more flexible 
 		### Paul B. changed: get_organelle_from_reads.py --overwrite -1 Data/$file_R1.gz -2 Data/$file_R2.gz -o GetOrg/"$sample"_pt \
@@ -111,6 +112,7 @@ if [ -s "$fastqFilePath/$file_path_R2" ]; then
 	then
 		### Paul B. changed: get_organelle_from_reads.py --overwrite -1 Data/$file_R1.gz -2 Data/$file_R2.gz -o GetOrg/"$sample"_nr \
 		### Paul B. changed: get_organelle_from_reads.py -1 $fastqFilePath/$file_path_R1 -2 $fastqFilePath/$file_path_R2 -o GetOrg/"$sample"_nr \
+    echo "[INFO] Recovering nuclear ribosomes..."
 		get_organelle_from_reads.py -1 $read1File -2 $read2File $unmappedFastqFiles  -o GetOrg/"$sample"_nr \
 		--max-reads 536870912 -R 10 -k 35,85,115 -t $ncpu -F embplant_nr --overwrite --zip-files > \
 		logs/log_${sample}_nr.log 2> logs/log_${sample}_nr.err
@@ -150,6 +152,7 @@ else
 
 	if [ $org == pt ] 
 	then
+    echo "[INFO] Recovering plastomes..."
 		### Paul B. - added '--overwrite 'otherwise get organelle will not run if folder already exists  
 		### Paul B changed: get_organelle_from_reads.py --overwrite -u Data/$file_R1.gz -o GetOrg/"$sample"_pt \
 		### Paul B. changed: get_organelle_from_reads.py -u $fastqFilePath/$file_path_R1 -o GetOrg/"$sample"_pt \
@@ -158,6 +161,7 @@ else
 		logs/log_${sample}_pt.log 2> logs/log_${sample}_pt.err
 	elif [ $org == nr ]
 	then
+    echo "[INFO] Recovering nuclear ribonomes..."
 		### Paul B. changed: get_organelle_from_reads.py --overwrite -u Data/$file_R1.gz -o GetOrg/"$sample"_nr \
 		### Paul B. changed: get_organelle_from_reads.py -u $fastqFilePath/$file_path_R1 -o GetOrg/"$sample"_nr \
 		get_organelle_from_reads.py -u $read1File -o GetOrg/"$sample"_nr \

--- a/PAFTOL_GetOrganelle/GetOrg_array.sh
+++ b/PAFTOL_GetOrganelle/GetOrg_array.sh
@@ -174,6 +174,3 @@ else
 fi
 
 python ../GetOrg_Clean.py --path GetOrg/"$sample"_"$org"/
-
-
-

--- a/PAFTOL_GetOrganelle/GetOrg_array.sh
+++ b/PAFTOL_GetOrganelle/GetOrg_array.sh
@@ -115,10 +115,10 @@ if [ -s "$fastqFilePath/$file_path_R2" ]; then
 		logs/log_${sample}_nr.log 2> logs/log_${sample}_nr.err
 	fi
 	# Delete the trimmed fastq.gz files only (NOT the original fastq files!):
-	if [[ -s ${sample}_R1_trimmomatic.fastq.gz ]]; then rm ${sample}_R1_trimmomatic.fastq.gz ${sample}_R2_trimmomatic.fastq.gz; fi
-	if [[ -s ${sample}_R1_trimmomatic_unpaired.fastq.gz ]]; then rm ${sample}_R1_trimmomatic_unpaired.fastq.gz ${sample}_R2_trimmomatic_unpaired.fastq.gz; fi
-	if [[ -s ${sample}_R2_trimmomatic_unpaired.fastq.gz ]]; then rm ${sample}_R2_trimmomatic_unpaired.fastq.gz; fi
-	if [[ -s ${sample}_R1_R2_trimmomatic.log ]]; then rm ${sample}_R1_R2_trimmomatic.log;fi
+	if [[ -s ${sample}_R1_trimmomatic.fastq.gz ]]; then rm -rf ${sample}_R1_trimmomatic.fastq.gz ${sample}_R2_trimmomatic.fastq.gz; fi
+	if [[ -s ${sample}_R1_trimmomatic_unpaired.fastq.gz ]]; then rm -rf ${sample}_R1_trimmomatic_unpaired.fastq.gz ${sample}_R2_trimmomatic_unpaired.fastq.gz; fi
+	if [[ -s ${sample}_R2_trimmomatic_unpaired.fastq.gz ]]; then rm -rf ${sample}_R2_trimmomatic_unpaired.fastq.gz; fi
+	if [[ -s ${sample}_R1_R2_trimmomatic.log ]]; then rm -rf ${sample}_R1_R2_trimmomatic.log;fi
 else
 	echo "Single-end Mode"
 

--- a/PAFTOL_GetOrganelle/GetOrg_array.sh
+++ b/PAFTOL_GetOrganelle/GetOrg_array.sh
@@ -44,7 +44,7 @@ if [ -s "$fastqFilePath/$file_path_R2" ]; then
 	unmappedFastqFiles=''
 	if [[ -s "${adapterFasta}" ]]; then
 		echo "Trimming PE fastq files..."
-		java -jar $TRIMMOMATIC PE \
+		java -jar $TRIMMOMATIC PE -phred33 \
 		-threads $ncpu \
 		-trimlog ${sample}_R1_R2_trimmomatic.log \
 		$fastqFilePath/$file_path_R1 \

--- a/PAFTOL_GetOrganelle/GetOrg_array.sh
+++ b/PAFTOL_GetOrganelle/GetOrg_array.sh
@@ -104,14 +104,14 @@ if [ -s "$fastqFilePath/$file_path_R2" ]; then
 		### Paul B deleted '--overwrite' option in 4 places below. No longer available in GetOrganelle v1.7.7.1, -o option overwrites instead
 		### Paul B. changed: get_organelle_from_reads.py -1 $fastqFilePath/$file_path_R1 -2 $fastqFilePath/$file_path_R2 -o GetOrg/"$sample"_pt \
 		get_organelle_from_reads.py -1 $read1File -2 $read2File $unmappedFastqFiles -o GetOrg/"$sample"_pt \
-		--max-reads 536870912 -R 20 -k 21,45,65,85,105 -t $ncpu -F embplant_pt --zip-files > \
+		--max-reads 536870912 -R 20 -k 21,45,65,85,105 -t $ncpu -F embplant_pt --overwrite --zip-files > \
 		logs/log_${sample}_pt.log 2> logs/log_${sample}_pt.err
 	elif [ $org == nr ]
 	then
 		### Paul B. changed: get_organelle_from_reads.py --overwrite -1 Data/$file_R1.gz -2 Data/$file_R2.gz -o GetOrg/"$sample"_nr \
 		### Paul B. changed: get_organelle_from_reads.py -1 $fastqFilePath/$file_path_R1 -2 $fastqFilePath/$file_path_R2 -o GetOrg/"$sample"_nr \
 		get_organelle_from_reads.py -1 $read1File -2 $read2File $unmappedFastqFiles  -o GetOrg/"$sample"_nr \
-		--max-reads 536870912 -R 10 -k 35,85,115 -t $ncpu -F embplant_nr --zip-files > \
+		--max-reads 536870912 -R 10 -k 35,85,115 -t $ncpu -F embplant_nr --overwrite --zip-files > \
 		logs/log_${sample}_nr.log 2> logs/log_${sample}_nr.err
 	fi
 	# Delete the trimmed fastq.gz files only (NOT the original fastq files!):
@@ -153,14 +153,14 @@ else
 		### Paul B changed: get_organelle_from_reads.py --overwrite -u Data/$file_R1.gz -o GetOrg/"$sample"_pt \
 		### Paul B. changed: get_organelle_from_reads.py -u $fastqFilePath/$file_path_R1 -o GetOrg/"$sample"_pt \
 		get_organelle_from_reads.py -u $read1File -o GetOrg/"$sample"_pt \
-		--max-reads 536870912 -R 20 -k 21,45,65,85,105 -t $ncpu -F embplant_pt --zip-files > \
+		--max-reads 536870912 -R 20 -k 21,45,65,85,105 -t $ncpu -F embplant_pt --overwrite --zip-files > \
 		logs/log_${sample}_pt.log 2> logs/log_${sample}_pt.err
 	elif [ $org == nr ]
 	then
 		### Paul B. changed: get_organelle_from_reads.py --overwrite -u Data/$file_R1.gz -o GetOrg/"$sample"_nr \
 		### Paul B. changed: get_organelle_from_reads.py -u $fastqFilePath/$file_path_R1 -o GetOrg/"$sample"_nr \
 		get_organelle_from_reads.py -u $read1File -o GetOrg/"$sample"_nr \
-		--max-reads 536870912 -R 10 -k 35,85,115 -t $ncpu -F embplant_nr --zip-files > \
+		--max-reads 536870912 -R 10 -k 35,85,115 -t $ncpu -F embplant_nr --overwrite --zip-files > \
 		logs/log_${sample}_nr.log 2> logs/log_${sample}_nr.err
 	fi
 	# Delete the trimmed fastq.gz files only (NOT the original fastq files!):

--- a/PAFTOL_GetOrganelle/GetOrg_array.sh
+++ b/PAFTOL_GetOrganelle/GetOrg_array.sh
@@ -16,6 +16,7 @@ ncpu=4
 sample_file=$1
 org=$2
 fastqFilePath=$3 	# Paul B. added: full path to files, replaces the 'Data' location
+                    # BG: leave empty if full path already provided in the sample file.
 adapterFasta=$4 	# Paul B. added: for adding the adaptor file, as required (might not be supplied)	
 
 iline=$(sed -n "$SLURM_ARRAY_TASK_ID"p $sample_file)

--- a/PAFTOL_GetOrganelle/GetOrg_array.sh
+++ b/PAFTOL_GetOrganelle/GetOrg_array.sh
@@ -89,6 +89,8 @@ if [ -s "$fastqFilePath/$file_path_R2" ]; then
 		fi
 		echo $unmappedFastqFiles
 	else
+        echo "[INFO] Trimmomatic not used to trim reads."
+        echo "[INFO] Adaptors fasta not provided or path not valid (provided: $adapterFasta)."
 		read1File=$fastqFilePath/$file_path_R1
 		read2File=$fastqFilePath/$file_path_R2
 	fi

--- a/PAFTOL_GetOrganelle/GetOrg_prep.py
+++ b/PAFTOL_GetOrganelle/GetOrg_prep.py
@@ -65,22 +65,34 @@ def add_fastq_files_paths(db, DataSource, src_path):
     print(db.shape[0],'samples in total')
     return db
 
-
 def flag_existing_recoveries(db, DataSource):
     """
-    List fasta_pt and fasta_nr
+    Searches fasta files in fasta_pt and fasta_nr directories, if exist.
+    Adds two boolean columns:
+        - fasta_pt: True if there is a file <Sample_Name>_pt.fasta
+        - fasta_nr: True if there is a file <Sample_Name>_nr.fasta
     """
-    db['fasta_pt']=False; db['fasta_nr']=False;
-    fasta_pt = pd.DataFrame(os.listdir(DataSource + '/fasta_pt/'),columns=['file'])
-    if fasta_pt.shape[0]>0:
-        fasta_pt['Sample_Name'] = fasta_pt.file.str.split('_pt',expand=True)[0]
-        db['fasta_pt']=db.Sample_Name.isin(fasta_pt.Sample_Name)
-    fasta_nr = pd.DataFrame(os.listdir(DataSource + '/fasta_nr/'),columns=['file'])
-    if fasta_nr.shape[0]>0:
-        fasta_nr['Sample_Name'] = fasta_nr.file.str.split('_nr',expand=True)[0]
-        db['fasta_nr']=db.Sample_Name.isin(fasta_nr.Sample_Name)
-    print(db.fasta_pt.sum(),'/',db.shape[0],'pt recovered')
-    print(db.fasta_nr.sum(),'/',db.shape[0],'nr recovered')
+    def mark_recovered(table, suffix):
+        fasta_dir = f"fasta_{suffix}"
+        path = os.path.join(DataSource, fasta_dir)
+        if not os.path.isdir(path):
+            table[f"{fasta_dir}"] = False
+            print(f"{fasta_dir} directory does not exist.")
+            return table
+        files = [f for f in os.listdir(path) if f.endswith('.fasta')]
+        if not files:
+            table[f"{fasta_dir}"] = False
+            print(f"No fasta files found in {fasta_dir}.")
+            return table
+        recovered = pd.Series(files).str.split(f"_{suffix}", expand=True)[0].unique()
+        table[f"fasta_{suffix}"] = table["Sample_Name"].isin(recovered)
+        print(f"{table[f'fasta_{suffix}'].sum()}/{len(table)} {suffix} recovered")
+        return table
+
+    db['fasta_pt'] = False
+    db['fasta_nr'] = False
+    db = mark_recovered(db, "pt")
+    db = mark_recovered(db, "nr")
     return db
 
 

--- a/PAFTOL_GetOrganelle/GetOrg_prep.py
+++ b/PAFTOL_GetOrganelle/GetOrg_prep.py
@@ -7,15 +7,11 @@
 # Copyright © 2020 The Board of Trustees of the Royal Botanic Gardens, Kew
 ##################################
 
-# In[1]:
-
-
 import pandas as pd
 import os; import sys
 import argparse
+from pathlib import Path
 
-
-# In[2]:
 
 def main():
     ## Parameters
@@ -45,29 +41,26 @@ def main():
     print("Done: prepared input files with accessions for recovery pipeline.")
 
 
-def add_fastq_files_paths(db, DataSource):
+def add_fastq_files_paths(db, DataSource, src_path):
+    """
+    Add Sample_Name, R1_path, and R2_path columns to db based on the DataSource.
+    DataSource can be 'PAFTOL', 'GAP', or 'SRA'.
+    """
+    fastq_path = src_path
     if DataSource == 'PAFTOL':
-        # Paul B. - modified path to process PAFTOL2.0 data
-        #fastq_path = '/science/projects/paftol/AllData_symlinks/'
-        fastq_path = '/science/projects/paftol/AllData_symlinks_PAFTOL2.0/'
-        db['Sample_Name'] = 'PAFTOL_' + db['idSequencing'].astype(int).astype('str').str.zfill(6)
-        db['R1_path'] = fastq_path + db.Sample_Name + '_R1.fastq.gz'
-        db['R2_path'] = fastq_path + db.Sample_Name + '_R2.fastq.gz'
+        db['Sample_Name'] = 'PAFTOL_' + db['idSequence'].astype(int).astype('str').str.zfill(6)
+        fastq_suffix = "R"
     elif DataSource == 'GAP':
-        fastq_path = '/science/projects/paftol/AllData_symlinks/'
-        db['Sample_Name'] = 'GAP_' + db['idSequencing'].astype(int).astype('str').str.zfill(6)
-        db['R1_path'] = fastq_path + db.Sample_Name + '_R1.fastq.gz'
-        db['R2_path'] = fastq_path + db.Sample_Name + '_R2.fastq.gz'
+        db['Sample_Name'] = 'GAP_' + db['idSequence'].astype(int).astype('str').str.zfill(6)
+        fastq_suffix = "R"
     elif DataSource == 'SRA':
-        # Paul B. - modified path to process SRA data from these subsets: paftol/SRA_from_ARZ/new_SRA_batch_2/SP014[678]
-        fastq_path = '/data/projects/paftol/SRA_Data/'
-        #fastq_path = '/data/projects/paftol/new_data_ARZ_Jan22/SP0147/'
-        db['Sample_Name'] = db.ExternalSequenceID
-        db['R1_path'] = fastq_path + db.R1FastqFile
-        db['R2_path'] = fastq_path + db.R2FastqFile
+        db['Sample_Name'] = db['ExternalSequenceID']
+        fastq_suffix = ""
     else:
         print('unknown action for',DataSource)
         sys.exit()
+    db["R1_path"] = db['Sample_Name'].apply(lambda x: fastq_path / f"{x}_{fastq_suffix}1.fastq.gz")
+    db["R2_path"] = db['Sample_Name'].apply(lambda x: fastq_path / f"{x}_{fastq_suffix}2.fastq.gz")
     print(db.shape[0],'samples in total')
     return db
 

--- a/PAFTOL_GetOrganelle/GetOrg_prep.py
+++ b/PAFTOL_GetOrganelle/GetOrg_prep.py
@@ -17,162 +17,172 @@ import argparse
 
 # In[2]:
 
+def main():
+    ## Parameters
+    parser = argparse.ArgumentParser(
+        description='Blast sample sequences on Barcode database and process the results')
+    parser.add_argument("--db", type=str, help="latest paftol_export")
+    parser.add_argument("--DataSource", type=str, help="DataSource (e.g. PAFTOL, SRA)")
+    parser.add_argument("--rem_search", type=str, help="List completed samples if fasta or log exist")
+    args = parser.parse_args()
 
-## Parameters
-parser = argparse.ArgumentParser(
-    description='Blast sample sequences on Barcode database and process the results')
-parser.add_argument("--db", type=str, help="latest paftol_export")
-parser.add_argument("--DataSource", type=str, help="DataSource (e.g. PAFTOL, SRA)")
-parser.add_argument("--rem_search", type=str, help="List completed samples if fasta or log exist")
-args = parser.parse_args()
+    export_file = args.db
+    DataSource = args.DataSource
+    rem_search = args.rem_search
 
-export_file = args.db
-DataSource = args.DataSource
-rem_search = args.rem_search
+    # Load export for datasource
+    db = pd.read_csv(export_file)
+    db = db[(db.DataSource==DataSource) & (db.R1FastqFile.notnull())]
 
-
-# In[3]:
-
-
-# # For notebook only
-# export_file = '../PAFTOL_DB/2021-07-27_paftol_export.csv'
-# DataSource = 'GAP'
-# rem_search = 'log'
+    db = add_fastq_files_paths(db, DataSource)
+    db = flag_existing_recoveries(db, DataSource)
+    db = add_past_recoveries_metadata_from_logs(db, DataSource)
+    todo_pt, todo_nr = get_input_files_for_missing_recoveries(db, DataSource, rem_search)
+    todo_pt, todo_nr = check_if_fastq_files_exists(db, DataSource)
+    save_recovery_pipeline_input_accessions_files(todo_pt, todo_nr)
+    print("Done: prepared input files with accessions for recovery pipeline.")
 
 
-# In[4]:
+def add_fastq_files_paths(db, DataSource):
+    if DataSource == 'PAFTOL':
+        # Paul B. - modified path to process PAFTOL2.0 data
+        #fastq_path = '/science/projects/paftol/AllData_symlinks/'
+        fastq_path = '/science/projects/paftol/AllData_symlinks_PAFTOL2.0/'
+        db['Sample_Name'] = 'PAFTOL_' + db['idSequencing'].astype(int).astype('str').str.zfill(6)
+        db['R1_path'] = fastq_path + db.Sample_Name + '_R1.fastq.gz'
+        db['R2_path'] = fastq_path + db.Sample_Name + '_R2.fastq.gz'
+    elif DataSource == 'GAP':
+        fastq_path = '/science/projects/paftol/AllData_symlinks/'
+        db['Sample_Name'] = 'GAP_' + db['idSequencing'].astype(int).astype('str').str.zfill(6)
+        db['R1_path'] = fastq_path + db.Sample_Name + '_R1.fastq.gz'
+        db['R2_path'] = fastq_path + db.Sample_Name + '_R2.fastq.gz'
+    elif DataSource == 'SRA':
+        # Paul B. - modified path to process SRA data from these subsets: paftol/SRA_from_ARZ/new_SRA_batch_2/SP014[678]
+        fastq_path = '/data/projects/paftol/SRA_Data/'
+        #fastq_path = '/data/projects/paftol/new_data_ARZ_Jan22/SP0147/'
+        db['Sample_Name'] = db.ExternalSequenceID
+        db['R1_path'] = fastq_path + db.R1FastqFile
+        db['R2_path'] = fastq_path + db.R2FastqFile
+    else:
+        print('unknown action for',DataSource)
+        sys.exit()
+    print(db.shape[0],'samples in total')
+    return db
 
-
-# Load export for datasource
-db = pd.read_csv(export_file)
-db = db[(db.DataSource==DataSource) & (db.R1FastqFile.notnull())]
-if DataSource == 'PAFTOL':
-    # Paul B. - modified path to process PAFTOL2.0 data
-    #fastq_path = '/science/projects/paftol/AllData_symlinks/'
-    fastq_path = '/science/projects/paftol/AllData_symlinks_PAFTOL2.0/'
-    db['Sample_Name'] = 'PAFTOL_' + db['idSequencing'].astype(int).astype('str').str.zfill(6)
-    db['R1_path'] = fastq_path + db.Sample_Name + '_R1.fastq.gz'
-    db['R2_path'] = fastq_path + db.Sample_Name + '_R2.fastq.gz'
-elif DataSource == 'GAP':
-    fastq_path = '/science/projects/paftol/AllData_symlinks/'
-    db['Sample_Name'] = 'GAP_' + db['idSequencing'].astype(int).astype('str').str.zfill(6)
-    db['R1_path'] = fastq_path + db.Sample_Name + '_R1.fastq.gz'
-    db['R2_path'] = fastq_path + db.Sample_Name + '_R2.fastq.gz'
-elif DataSource == 'SRA':
-    # Paul B. - modified path to process SRA data from these subsets: paftol/SRA_from_ARZ/new_SRA_batch_2/SP014[678]
-    fastq_path = '/data/projects/paftol/SRA_Data/'
-    #fastq_path = '/data/projects/paftol/new_data_ARZ_Jan22/SP0147/'
-    db['Sample_Name'] = db.ExternalSequenceID
-    db['R1_path'] = fastq_path + db.R1FastqFile
-    db['R2_path'] = fastq_path + db.R2FastqFile
-else:
-    print('unknown action for',DataSource)
-    sys.exit()
-
-print(db.shape[0],'samples in total')
 
 
 # In[5]:
 
 
-# List fasta_pt and fasta_nr
-db['fasta_pt']=False; db['fasta_nr']=False;
-fasta_pt = pd.DataFrame(os.listdir(DataSource + '/fasta_pt/'),columns=['file'])
-if fasta_pt.shape[0]>0:
-    fasta_pt['Sample_Name'] = fasta_pt.file.str.split('_pt',expand=True)[0]
-    db['fasta_pt']=db.Sample_Name.isin(fasta_pt.Sample_Name)
-fasta_nr = pd.DataFrame(os.listdir(DataSource + '/fasta_nr/'),columns=['file'])
-if fasta_nr.shape[0]>0:
-    fasta_nr['Sample_Name'] = fasta_nr.file.str.split('_nr',expand=True)[0]
-    db['fasta_nr']=db.Sample_Name.isin(fasta_nr.Sample_Name)
-print(db.fasta_pt.sum(),'/',db.shape[0],'pt recovered')
-print(db.fasta_nr.sum(),'/',db.shape[0],'nr recovered')
+def flag_existing_recoveries(db, DataSource):
+    """
+    List fasta_pt and fasta_nr
+    """
+    db['fasta_pt']=False; db['fasta_nr']=False;
+    fasta_pt = pd.DataFrame(os.listdir(DataSource + '/fasta_pt/'),columns=['file'])
+    if fasta_pt.shape[0]>0:
+        fasta_pt['Sample_Name'] = fasta_pt.file.str.split('_pt',expand=True)[0]
+        db['fasta_pt']=db.Sample_Name.isin(fasta_pt.Sample_Name)
+    fasta_nr = pd.DataFrame(os.listdir(DataSource + '/fasta_nr/'),columns=['file'])
+    if fasta_nr.shape[0]>0:
+        fasta_nr['Sample_Name'] = fasta_nr.file.str.split('_nr',expand=True)[0]
+        db['fasta_nr']=db.Sample_Name.isin(fasta_nr.Sample_Name)
+    print(db.fasta_pt.sum(),'/',db.shape[0],'pt recovered')
+    print(db.fasta_nr.sum(),'/',db.shape[0],'nr recovered')
+    return db
 
 
 # In[6]:
 
 
 # Check logs
-db['log_pt']=False; db['log_nr']=False;
-logs_df = pd.DataFrame(os.listdir(DataSource + '/logs/'),columns=['file'])
-if logs_df.shape[0]>0:
-    logs_df['Sample_Name'] = logs_df.file.str.split('log_',expand=True)[1]
-    logs_df['Type'] = logs_df.Sample_Name.str.split('.',expand=True)[1]
-    logs_df['Sample_Name'] = logs_df.Sample_Name.str.split('.',expand=True)[0]
-    logs_df['Organelle'] = logs_df.Sample_Name.str.split('_').str[-1]
-    logs_df['Sample_Name'] = logs_df.Sample_Name.str.replace('_nr','').str.replace('_pt','')
-    logs_df['filesize']=logs_df.file.apply(lambda x: os.stat(DataSource + '/logs/' + x).st_size)
-    db['log_pt']=db.Sample_Name.isin(logs_df[(logs_df.Type=='log') & (logs_df.Organelle=='pt')]['Sample_Name'])
-    db['log_nr']=db.Sample_Name.isin(logs_df[(logs_df.Type=='log') & (logs_df.Organelle=='nr')]['Sample_Name'])
-print(db.log_pt.sum(),'/',db.shape[0],'pt processed')
-print(db.log_nr.sum(),'/',db.shape[0],'nr processed')
-if logs_df.shape[0]>0:
-    db['error_pt']=pd.merge(db, logs_df[(logs_df.Type=='err') & (logs_df.Organelle=='pt')]).filesize > 0
-    db['error_nr']=pd.merge(db, logs_df[(logs_df.Type=='err') & (logs_df.Organelle=='nr')]).filesize > 0
-    print(db.error_pt.sum(),'/',db.shape[0],'error during pt recovery')
-    print(db.error_nr.sum(),'/',db.shape[0],'error during nr recovery')
 
+def add_past_recoveries_metadata_from_logs(db, DataSource):
+    db['log_pt']=False; db['log_nr']=False;
+    logs_df = pd.DataFrame(os.listdir(DataSource + '/logs/'),columns=['file'])
+    if logs_df.shape[0]>0:
+        logs_df['Sample_Name'] = logs_df.file.str.split('log_',expand=True)[1]
+        logs_df['Type'] = logs_df.Sample_Name.str.split('.',expand=True)[1]
+        logs_df['Sample_Name'] = logs_df.Sample_Name.str.split('.',expand=True)[0]
+        logs_df['Organelle'] = logs_df.Sample_Name.str.split('_').str[-1]
+        logs_df['Sample_Name'] = logs_df.Sample_Name.str.replace('_nr','').str.replace('_pt','')
+        logs_df['filesize']=logs_df.file.apply(lambda x: os.stat(DataSource + '/logs/' + x).st_size)
+        db['log_pt']=db.Sample_Name.isin(logs_df[(logs_df.Type=='log') & (logs_df.Organelle=='pt')]['Sample_Name'])
+        db['log_nr']=db.Sample_Name.isin(logs_df[(logs_df.Type=='log') & (logs_df.Organelle=='nr')]['Sample_Name'])
+    print(db.log_pt.sum(),'/',db.shape[0],'pt processed')
+    print(db.log_nr.sum(),'/',db.shape[0],'nr processed')
+    if logs_df.shape[0]>0:
+        db['error_pt']=pd.merge(db, logs_df[(logs_df.Type=='err') & (logs_df.Organelle=='pt')]).filesize > 0
+        db['error_nr']=pd.merge(db, logs_df[(logs_df.Type=='err') & (logs_df.Organelle=='nr')]).filesize > 0
+        print(db.error_pt.sum(),'/',db.shape[0],'error during pt recovery')
+        print(db.error_nr.sum(),'/',db.shape[0],'error during nr recovery')
+    return db
 
-# In[7]:
-
-
-if rem_search == 'fasta':
-    todo_pt = db[(db.fasta_pt==False)][['Sample_Name','R1_path','R2_path']]
-    todo_nr = db[(db.fasta_nr==False)][['Sample_Name','R1_path','R2_path']]
-elif rem_search == 'log':
-    todo_pt = db[(db.log_pt==False)][['Sample_Name','R1_path','R2_path']]
-    todo_nr = db[(db.log_nr==False)][['Sample_Name','R1_path','R2_path']]
-if todo_pt.shape[0]>0:
-    print('\n',todo_pt.shape[0],DataSource,'samples listed for pt recovery')
-if todo_nr.shape[0]>0:
-    print('\n',todo_nr.shape[0],DataSource,'samples listed for nr recovery')
 
 
 # In[ ]:
 
-
-if todo_pt.shape[0]>0:
-    for idx, row in todo_pt.iterrows():
-#         print(row['R1_path'],end=':'); print(os.path.exists(row['R1_path']))
-        todo_pt.loc[idx,'R1_exist'] = os.path.exists( str(row['R1_path']) )
-        if os.path.exists( str(row['R1_path']) ):
-            todo_pt.loc[idx,'R1_size'] = os.stat( str(row['R1_path']) ).st_size
-#         print(row['R2_path'],end=':'); print(os.path.exists( str(row['R2_path']) ))
-        todo_pt.loc[idx,'R2_exist'] = os.path.exists( str(row['R2_path']) )
-# Paul B. added - sort by file size
-todo_pt = todo_pt.sort_values(by='R1_size')
-pd.set_option('display.max_rows', len(todo_pt)) # -->  pd.reset_option('display.max_rows')
-print(todo_pt[['Sample_Name','R1_size']])
-### Paul B. - trying to accept single-end data also for SRA samples)
-# todo_pt = todo_pt[(todo_pt.R1_exist) & (todo_pt.R2_exist)]
-todo_pt = todo_pt[ ( (todo_pt.R1_exist) & (todo_pt.R2_exist) ) | ( todo_pt.R1_exist & todo_pt.R2_exist.isnull() ) ]
-if todo_pt.shape[0]>0:
-    #print(todo_pt.shape[0],'paired-end fastq files found')
-    print(todo_pt.shape[0],'paired-end or single-end fastq files found')
-    todo_pt[['Sample_Name','R1_path','R2_path']].to_csv(DataSource + '/remaining_pt.txt',index=False,header=None)
-else:
-    print('no fastq file found or no sample to process, remaining list not written')
-
-if todo_nr.shape[0]>0:
-    for idx, row in todo_nr.iterrows():
-#         print(row['R1_path'],end=':'); print(os.path.exists( str(row['R1_path']) )
-        todo_nr.loc[idx,'R1_exist'] = os.path.exists( str(row['R1_path']) )
-        if os.path.exists( str(row['R1_path']) ):
-            todo_nr.loc[idx,'R1_size'] = os.stat( str(row['R1_path']) ).st_size
-#         print(row['R2_path'],end=':'); print(os.path.exists( str(row['R2_path']))
-        todo_nr.loc[idx,'R2_exist'] = os.path.exists( str(row['R2_path']) )
-# Paul B. added - sort by file size
-todo_nr = todo_nr.sort_values(by='R1_size')
-#todo_nr = todo_nr[(todo_nr.R1_exist) & (todo_nr.R2_exist)]
-todo_nr = todo_nr[ ((todo_nr.R1_exist) & (todo_nr.R2_exist)) | (todo_nr.R1_exist & todo_nr.R2_exist.isnull()) ]
-if todo_nr.shape[0]>0:
-    #print(todo_nr.shape[0],'paired-end fastq files found')
-    print(todo_nr.shape[0],'paired-end or single-end fastq files found')
-    todo_nr[['Sample_Name','R1_path','R2_path']].to_csv(DataSource + '/remaining_nr.txt',index=False,header=None)
-else:
-    print('no fastq file found or no sample to process, remaining list not written')
+def get_input_files_for_missing_recoveries(db, DataSource, rem_search):
+    # TODO: use function for each data type instead of repeating code
+    if rem_search == 'fasta':
+        todo_pt = db[(db.fasta_pt==False)][['Sample_Name','R1_path','R2_path']]
+        todo_nr = db[(db.fasta_nr==False)][['Sample_Name','R1_path','R2_path']]
+    elif rem_search == 'log':
+        todo_pt = db[(db.log_pt==False)][['Sample_Name','R1_path','R2_path']]
+        todo_nr = db[(db.log_nr==False)][['Sample_Name','R1_path','R2_path']]
+    if todo_pt.shape[0]>0:
+        print('\n',todo_pt.shape[0],DataSource,'samples listed for pt recovery')
+    if todo_nr.shape[0]>0:
+        print('\n',todo_nr.shape[0],DataSource,'samples listed for nr recovery')
+    return todo_pt, todo_nr
 
 
+
+def check_if_fastq_files_exists(todo_pt, todo_nr):
+    # TODO: use function for each data type instead of repeating code
+    if todo_pt.shape[0]>0:
+        for idx, row in todo_pt.iterrows():
+    #         print(row['R1_path'],end=':'); print(os.path.exists(row['R1_path']))
+            todo_pt.loc[idx,'R1_exist'] = os.path.exists( str(row['R1_path']) )
+            if os.path.exists( str(row['R1_path']) ):
+                todo_pt.loc[idx,'R1_size'] = os.stat( str(row['R1_path']) ).st_size
+    #         print(row['R2_path'],end=':'); print(os.path.exists( str(row['R2_path']) ))
+            todo_pt.loc[idx,'R2_exist'] = os.path.exists( str(row['R2_path']) )
+    # Paul B. added - sort by file size
+    todo_pt = todo_pt.sort_values(by='R1_size')
+    pd.set_option('display.max_rows', len(todo_pt)) # -->  pd.reset_option('display.max_rows')
+    print(todo_pt[['Sample_Name','R1_size']])
+    ### Paul B. - trying to accept single-end data also for SRA samples)
+    # todo_pt = todo_pt[(todo_pt.R1_exist) & (todo_pt.R2_exist)]
+    todo_pt = todo_pt[ ( (todo_pt.R1_exist) & (todo_pt.R2_exist) ) | ( todo_pt.R1_exist & todo_pt.R2_exist.isnull() ) ]
+
+    if todo_nr.shape[0]>0:
+        for idx, row in todo_nr.iterrows():
+    #         print(row['R1_path'],end=':'); print(os.path.exists( str(row['R1_path']) )
+            todo_nr.loc[idx,'R1_exist'] = os.path.exists( str(row['R1_path']) )
+            if os.path.exists( str(row['R1_path']) ):
+                todo_nr.loc[idx,'R1_size'] = os.stat( str(row['R1_path']) ).st_size
+    #         print(row['R2_path'],end=':'); print(os.path.exists( str(row['R2_path']))
+            todo_nr.loc[idx,'R2_exist'] = os.path.exists( str(row['R2_path']) )
+    # Paul B. added - sort by file size
+    todo_nr = todo_nr.sort_values(by='R1_size')
+    #todo_nr = todo_nr[(todo_nr.R1_exist) & (todo_nr.R2_exist)]
+    todo_nr = todo_nr[ ((todo_nr.R1_exist) & (todo_nr.R2_exist)) | (todo_nr.R1_exist & todo_nr.R2_exist.isnull()) ]
+    return todo_pt, todo_nr
+
+def save_recovery_pipeline_input_accessions_files(todo_pt, todo_nr):
+    if todo_pt.shape[0]>0:
+        #print(todo_pt.shape[0],'paired-end fastq files found')
+        print(todo_pt.shape[0],'paired-end or single-end fastq files found')
+        todo_pt[['Sample_Name','R1_path','R2_path']].to_csv(DataSource + '/remaining_pt.txt',index=False,header=None)
+    else:
+        print('no fastq file found or no sample to process, remaining list not written')
+    if todo_nr.shape[0]>0:
+        #print(todo_nr.shape[0],'paired-end fastq files found')
+        print(todo_nr.shape[0],'paired-end or single-end fastq files found')
+        todo_nr[['Sample_Name','R1_path','R2_path']].to_csv(DataSource + '/remaining_nr.txt',index=False,header=None)
+    else:
+        print('no fastq file found or no sample to process, remaining list not written')
 # In[ ]:
 
 
@@ -194,3 +204,5 @@ else:
 #     print(todo_nr.shape[0],'paired-end fastq files found')
 #     todo_nr[['Sample_Name','R1_path','R2_path']].to_csv(DataSource + '/remaining_nr.txt',index=False,header=None)
 
+if __name__ == "__main__":
+    main()

--- a/PAFTOL_GetOrganelle/GetOrg_prep.py
+++ b/PAFTOL_GetOrganelle/GetOrg_prep.py
@@ -155,35 +155,49 @@ def get_input_files_for_missing_recoveries(db, DataSource, rem_search):
 
 
 def check_if_fastq_files_exists(todo_pt, todo_nr):
-    # TODO: use function for each data type instead of repeating code
-    if todo_pt.shape[0]>0:
-        for idx, row in todo_pt.iterrows():
-    #         print(row['R1_path'],end=':'); print(os.path.exists(row['R1_path']))
-            todo_pt.loc[idx,'R1_exist'] = os.path.exists( str(row['R1_path']) )
-            if os.path.exists( str(row['R1_path']) ):
-                todo_pt.loc[idx,'R1_size'] = os.stat( str(row['R1_path']) ).st_size
-    #         print(row['R2_path'],end=':'); print(os.path.exists( str(row['R2_path']) ))
-            todo_pt.loc[idx,'R2_exist'] = os.path.exists( str(row['R2_path']) )
-    # Paul B. added - sort by file size
-    todo_pt = todo_pt.sort_values(by='R1_size')
-    pd.set_option('display.max_rows', len(todo_pt)) # -->  pd.reset_option('display.max_rows')
-    print(todo_pt[['Sample_Name','R1_size']])
-    ### Paul B. - trying to accept single-end data also for SRA samples)
-    # todo_pt = todo_pt[(todo_pt.R1_exist) & (todo_pt.R2_exist)]
-    todo_pt = todo_pt[ ( (todo_pt.R1_exist) & (todo_pt.R2_exist) ) | ( todo_pt.R1_exist & todo_pt.R2_exist.isnull() ) ]
+    """
+    Check existence and size of R1/R2 FASTQ files, and remove empty ones from
+    tables.
+    """
+    def check_fastq_table(df):
+        """
+        Add existence and size columns, filter out missing or empty files.
+        """
+        if df.empty:
+            return df
+        df = df.copy()
+        df['R1_path'] = df['R1_path'].astype(str)
+        df['R2_path'] = df['R2_path'].astype(str)
+        df['R1_exist'] = df['R1_path'].apply(os.path.exists)
+        df['R2_exist'] = df['R2_path'].apply(lambda x: os.path.exists(x) if pd.notna(x) else False)
+        df['R1_size'] = df['R1_path'].apply(lambda x: os.path.getsize(x) if os.path.exists(x) else 0)
+        df['R2_size'] = df['R2_path'].apply(lambda x: os.path.getsize(x) if os.path.exists(x) else 0)
 
-    if todo_nr.shape[0]>0:
-        for idx, row in todo_nr.iterrows():
-    #         print(row['R1_path'],end=':'); print(os.path.exists( str(row['R1_path']) )
-            todo_nr.loc[idx,'R1_exist'] = os.path.exists( str(row['R1_path']) )
-            if os.path.exists( str(row['R1_path']) ):
-                todo_nr.loc[idx,'R1_size'] = os.stat( str(row['R1_path']) ).st_size
-    #         print(row['R2_path'],end=':'); print(os.path.exists( str(row['R2_path']))
-            todo_nr.loc[idx,'R2_exist'] = os.path.exists( str(row['R2_path']) )
-    # Paul B. added - sort by file size
-    todo_nr = todo_nr.sort_values(by='R1_size')
-    #todo_nr = todo_nr[(todo_nr.R1_exist) & (todo_nr.R2_exist)]
-    todo_nr = todo_nr[ ((todo_nr.R1_exist) & (todo_nr.R2_exist)) | (todo_nr.R1_exist & todo_nr.R2_exist.isnull()) ]
+        # Drop rows where R1 is missing or empty
+        df = df[(df['R1_exist']) & (df['R1_size'] > 0)]
+
+        # Keep either paired-end (R1 & R2 exist) or valid single-end (R2 missing)
+        df = df[(df['R2_exist']) | (df['R2_path'].isna())]
+
+        # Identify problematic rows
+        invalid = df[
+            (~df['R1_exist']) | (df['R1_size'] == 0) |
+            ((df['R2_exist']) & (df['R2_size'] == 0))
+        ]
+
+        # Keep only valid entries
+        valid = df[
+            (df['R1_exist']) & (df['R1_size'] > 0)
+        ]
+
+        return invalid, valid.sort_values(by='R1_size', ascending=False).reset_index(drop=True)
+
+    todo_pt_invalid, todo_pt = check_fastq_table(todo_pt)
+    todo_nr_invalid, todo_nr = check_fastq_table(todo_nr)
+
+    todo_pt_invalid.to_csv("todo_pt_invalid.csv", index=False)
+    todo_nr_invalid.to_csv("todo_nr_invalid.csv", index=False)
+    print(f"Saved CSVs with {len(todo_pt_invalid)} invalid fastq metadata.")
     return todo_pt, todo_nr
 
 

--- a/PAFTOL_GetOrganelle/GetOrg_prep.py
+++ b/PAFTOL_GetOrganelle/GetOrg_prep.py
@@ -16,7 +16,7 @@ from pathlib import Path
 def main():
     ## Parameters
     parser = argparse.ArgumentParser(
-        description='Blast sample sequences on Barcode database and process the results')
+        description='Prepare sample list for the organelle recovery pipeline.')
     parser.add_argument("--db", type=str, help="latest paftol_export")
     parser.add_argument("--DataSource", type=str, help="DataSource (e.g. PAFTOL, SRA)")
     parser.add_argument("--src_path", type=str, help="Absolute path to the directory with all the symlinks to the source files (e.g. /mnt/projects/...)")

--- a/PAFTOL_GetOrganelle/GetOrg_prep.py
+++ b/PAFTOL_GetOrganelle/GetOrg_prep.py
@@ -23,12 +23,14 @@ def main():
         description='Blast sample sequences on Barcode database and process the results')
     parser.add_argument("--db", type=str, help="latest paftol_export")
     parser.add_argument("--DataSource", type=str, help="DataSource (e.g. PAFTOL, SRA)")
+    parser.add_argument("--src_path", type=str, help="Absolute path to the directory with all the symlinks to the source files (e.g. /mnt/projects/...)")
     parser.add_argument("--rem_search", type=str, help="List completed samples if fasta or log exist")
     args = parser.parse_args()
 
     export_file = args.db
     DataSource = args.DataSource
     rem_search = args.rem_search
+    src_path = Path(args.src_path)
 
     # Load export for datasource
     db = pd.read_csv(export_file)

--- a/PAFTOL_GetOrganelle/GetOrg_prep.py
+++ b/PAFTOL_GetOrganelle/GetOrg_prep.py
@@ -97,24 +97,45 @@ def flag_existing_recoveries(db, DataSource):
 
 
 def add_past_recoveries_metadata_from_logs(db, DataSource):
-    db['log_pt']=False; db['log_nr']=False;
-    logs_df = pd.DataFrame(os.listdir(DataSource + '/logs/'),columns=['file'])
-    if logs_df.shape[0]>0:
-        logs_df['Sample_Name'] = logs_df.file.str.split('log_',expand=True)[1]
-        logs_df['Type'] = logs_df.Sample_Name.str.split('.',expand=True)[1]
-        logs_df['Sample_Name'] = logs_df.Sample_Name.str.split('.',expand=True)[0]
-        logs_df['Organelle'] = logs_df.Sample_Name.str.split('_').str[-1]
-        logs_df['Sample_Name'] = logs_df.Sample_Name.str.replace('_nr','').str.replace('_pt','')
-        logs_df['filesize']=logs_df.file.apply(lambda x: os.stat(DataSource + '/logs/' + x).st_size)
-        db['log_pt']=db.Sample_Name.isin(logs_df[(logs_df.Type=='log') & (logs_df.Organelle=='pt')]['Sample_Name'])
-        db['log_nr']=db.Sample_Name.isin(logs_df[(logs_df.Type=='log') & (logs_df.Organelle=='nr')]['Sample_Name'])
-    print(db.log_pt.sum(),'/',db.shape[0],'pt processed')
-    print(db.log_nr.sum(),'/',db.shape[0],'nr processed')
-    if logs_df.shape[0]>0:
-        db['error_pt']=pd.merge(db, logs_df[(logs_df.Type=='err') & (logs_df.Organelle=='pt')]).filesize > 0
-        db['error_nr']=pd.merge(db, logs_df[(logs_df.Type=='err') & (logs_df.Organelle=='nr')]).filesize > 0
-        print(db.error_pt.sum(),'/',db.shape[0],'error during pt recovery')
-        print(db.error_nr.sum(),'/',db.shape[0],'error during nr recovery')
+    db = db.copy()
+    db['log_pt'] = False
+    db['log_nr'] = False
+    db['error_pt'] = False
+    db['error_nr'] = False
+
+    log_path = os.path.join(DataSource, 'logs')
+    os.makedirs(log_path, exist_ok=True)
+    logs_df = pd.DataFrame(os.listdir(log_path), columns=['file'])
+
+    if not logs_df.empty:
+        # Add metadata to log file names
+        logs_df['Sample_Name'] = logs_df['file'].str.split('log_', expand=True)[1]
+        logs_df['Type'] = logs_df['Sample_Name'].str.split('.', expand=True)[1]
+        logs_df['Sample_Name'] = logs_df['Sample_Name'].str.split('.', expand=True)[0]
+        logs_df['Organelle'] = logs_df['Sample_Name'].str.split('_').str[-1]
+        logs_df['Sample_Name'] = logs_df['Sample_Name'].str.replace('_nr','').str.replace('_pt','')
+        logs_df['filesize'] = logs_df['file'].apply(lambda x: os.stat(os.path.join(log_path, x)).st_size)
+
+        # Add True if log file exists
+        db['log_pt'] = db['Sample_Name'].isin(
+            logs_df.query("Type == 'log' and Organelle == 'pt'")['Sample_Name']
+        )
+        db['log_nr'] = db['Sample_Name'].isin(
+            logs_df.query("Type == 'log' and Organelle == 'nr'")['Sample_Name']
+        )
+
+        # Add True if if log contains error
+        err_pt = logs_df.query("Type == 'err' and Organelle == 'pt' and filesize > 0")
+        err_nr = logs_df.query("Type == 'err' and Organelle == 'nr' and filesize > 0")
+        db['error_pt'] = db['Sample_Name'].isin(err_pt['Sample_Name'])
+        db['error_nr'] = db['Sample_Name'].isin(err_nr['Sample_Name'])
+
+    # Show number of log files found
+    print(db['log_pt'].sum(), '/', len(db), 'pt processed')
+    print(db['log_nr'].sum(), '/', len(db), 'nr processed')
+    # Show number of log files with error
+    print(db['error_pt'].sum(), '/', len(db), 'error during pt recovery')
+    print(db['error_nr'].sum(), '/', len(db), 'error during nr recovery')
     return db
 
 

--- a/PAFTOL_GetOrganelle/GetOrg_prep.py
+++ b/PAFTOL_GetOrganelle/GetOrg_prep.py
@@ -70,10 +70,6 @@ def add_fastq_files_paths(db, DataSource):
     return db
 
 
-
-# In[5]:
-
-
 def flag_existing_recoveries(db, DataSource):
     """
     List fasta_pt and fasta_nr
@@ -91,11 +87,6 @@ def flag_existing_recoveries(db, DataSource):
     print(db.fasta_nr.sum(),'/',db.shape[0],'nr recovered')
     return db
 
-
-# In[6]:
-
-
-# Check logs
 
 def add_past_recoveries_metadata_from_logs(db, DataSource):
     db['log_pt']=False; db['log_nr']=False;
@@ -119,9 +110,6 @@ def add_past_recoveries_metadata_from_logs(db, DataSource):
     return db
 
 
-
-# In[ ]:
-
 def get_input_files_for_missing_recoveries(db, DataSource, rem_search):
     # TODO: use function for each data type instead of repeating code
     if rem_search == 'fasta':
@@ -135,7 +123,6 @@ def get_input_files_for_missing_recoveries(db, DataSource, rem_search):
     if todo_nr.shape[0]>0:
         print('\n',todo_nr.shape[0],DataSource,'samples listed for nr recovery')
     return todo_pt, todo_nr
-
 
 
 def check_if_fastq_files_exists(todo_pt, todo_nr):
@@ -170,6 +157,7 @@ def check_if_fastq_files_exists(todo_pt, todo_nr):
     todo_nr = todo_nr[ ((todo_nr.R1_exist) & (todo_nr.R2_exist)) | (todo_nr.R1_exist & todo_nr.R2_exist.isnull()) ]
     return todo_pt, todo_nr
 
+
 def save_recovery_pipeline_input_accessions_files(todo_pt, todo_nr):
     if todo_pt.shape[0]>0:
         #print(todo_pt.shape[0],'paired-end fastq files found')
@@ -183,8 +171,6 @@ def save_recovery_pipeline_input_accessions_files(todo_pt, todo_nr):
         todo_nr[['Sample_Name','R1_path','R2_path']].to_csv(DataSource + '/remaining_nr.txt',index=False,header=None)
     else:
         print('no fastq file found or no sample to process, remaining list not written')
-# In[ ]:
-
 
 # if todo_pt.shape[0]>0:
 #     todo_pt['R1_exist'] = todo_pt.apply(lambda row: os.path.exists(row['R1_path']),axis=1)

--- a/PAFTOL_GetOrganelle/GetOrg_prep.py
+++ b/PAFTOL_GetOrganelle/GetOrg_prep.py
@@ -30,7 +30,8 @@ def main():
 
     # Load export for datasource
     db = pd.read_csv(export_file)
-    db = db[(db.DataSource==DataSource) & (db.R1FastqFile.notnull())]
+    db = db[(db.DataSource==DataSource)]
+    print("PAFTOL export loaded.\n")
 
     db = add_fastq_files_paths(db, DataSource)
     db = flag_existing_recoveries(db, DataSource)

--- a/PAFTOL_GetOrganelle/GetOrg_prep.py
+++ b/PAFTOL_GetOrganelle/GetOrg_prep.py
@@ -33,12 +33,26 @@ def main():
     db = db[(db.DataSource==DataSource)]
     print("PAFTOL export loaded.\n")
 
-    db = add_fastq_files_paths(db, DataSource)
+    print("\nAdding fastq paths...")
+    db = add_fastq_files_paths(db, DataSource, src_path)
+    print("Fastq paths added.")
+
+    print("\nFlagging existing recoveries...")
     db = flag_existing_recoveries(db, DataSource)
+    print("Existing recoveries flagged.")
+
+    print(f"\nAdding metadata from recovery {rem_search}...")
     db = add_past_recoveries_metadata_from_logs(db, DataSource)
     todo_pt, todo_nr = get_input_files_for_missing_recoveries(db, DataSource, rem_search)
-    todo_pt, todo_nr = check_if_fastq_files_exists(db, DataSource)
-    save_recovery_pipeline_input_accessions_files(todo_pt, todo_nr)
+    print("Existing recoveries metadata from logs added.")
+
+    print("\nChecking if fastq files exist...")
+    todo_pt, todo_nr = check_if_fastq_files_exists(todo_pt, todo_nr)
+    todo_nr.to_csv("todo_nr.csv", index=False)
+    todo_pt.to_csv("todo_pt.csv", index=False)
+
+    print("\nSaving file..")
+    save_recovery_pipeline_input_accessions_files(DataSource, todo_pt, todo_nr)
     print("Done: prepared input files with accessions for recovery pipeline.")
 
 

--- a/PAFTOL_GetOrganelle/GetOrg_prep.py
+++ b/PAFTOL_GetOrganelle/GetOrg_prep.py
@@ -201,7 +201,7 @@ def check_if_fastq_files_exists(todo_pt, todo_nr):
     return todo_pt, todo_nr
 
 
-def save_recovery_pipeline_input_accessions_files(todo_pt, todo_nr):
+def save_recovery_pipeline_input_accessions_files(DataSource, todo_pt, todo_nr):
     if todo_pt.shape[0]>0:
         #print(todo_pt.shape[0],'paired-end fastq files found')
         print(todo_pt.shape[0],'paired-end or single-end fastq files found')


### PR DESCRIPTION
The main reasons for the refactoring were allowing more flexibility to:
- Use a custom path to the fastq files, instead of hard-coding it for the data source.
- Use a custom sample list or the sample list produced by the pipeline.
- Run the sample preparation script together with the rest of the pipeline or not.

Also:
- GetOrg_prep has been refactored to avoid code repetition for each of the organelles.

Other changes:
- Added run options, like -phred33 to Trimmomatic or --overwrite to get_organelle_from_runs.
- Added some run info.